### PR TITLE
Adds conditional check to determine how to log

### DIFF
--- a/lib/speechpad.rb
+++ b/lib/speechpad.rb
@@ -1,4 +1,5 @@
 require 'speechpad/client'
+require 'logger'
 
 module Speechpad
   class << self

--- a/lib/speechpad/connection.rb
+++ b/lib/speechpad/connection.rb
@@ -8,8 +8,9 @@ module Speechpad
 
     def connection(options={})
       connection = Faraday.new @speechpad_url do |conn|
-        # Uncomment if want to log to stdout
-        #conn.response :logger
+        unless ENV['SPEECHPAD_VERBOSE']
+          conn.response :logger, ::Logger.new("/dev/null")
+        end
 
         conn.request :url_encoded
         conn.response :mashify


### PR DESCRIPTION
With `conn.response :logger` commented out, speechpad will still log to stdout
when included in Rails project.

This change allows the use of ENV['SPEECHPAD_VERBOSE'] when more info is 
desired and quiet by default :).
